### PR TITLE
Configurable path for the tor data directory

### DIFF
--- a/CPAProxy/CPAConfiguration.h
+++ b/CPAProxy/CPAConfiguration.h
@@ -18,20 +18,24 @@
  
  @param Path to a torrc file.
  @param Path to a geoip file.
+ @param Path to directory to be used as teh tor data directory if set to nil then a directory is created in the system temporary directory
  @return A newly initialized `CPAConfiguration`.
  */
 + (instancetype)configurationWithTorrcPath:(NSString *)torrcPath
-                                 geoipPath:(NSString *)geoipPath;
+                                 geoipPath:(NSString *)geoipPath
+                      torDataDirectoryPath:(NSString *)torDataDirectoryPath;
 
 /**
  Initializes a `CPAConfiguration` with the specified torrc and geoip paths.
  
  @param torrcPath Path to a torrc file.
  @param geoipPath Path to a geoip file.
+ @param Path to directory to be used as teh tor data directory if set to nil then a directory is created in the system temporary directory
  @return A newly initialized `CPAConfiguration`.
  */
 - (instancetype)initWithTorrcPath:(NSString *)torrcPath
-                        geoipPath:(NSString *)geoipPath;
+                        geoipPath:(NSString *)geoipPath
+             torDataDirectoryPath:(NSString *)torDataDirectoryPath;
 
 /**
  The port for the Tor SOCKS proxy.
@@ -59,9 +63,9 @@
 @property (nonatomic, copy, readonly) NSString *torCookieDataAsHex;
 
 /**
- Returns the path to the Tor temporary directory.
+ Returns the path to the Tor data directory.
  */
-@property (nonatomic, copy, readonly) NSString *torTempDirPath;
+@property (nonatomic, copy, readonly) NSString *torDataDirectoryPath;
 
 /**
  Returns the path to the torrc file.

--- a/CPAProxy/CPAThread.m
+++ b/CPAProxy/CPAThread.m
@@ -46,7 +46,7 @@ const char *kTorArgsValueLogLevel = "notice stderr";
 
 - (void)main
 {
-    NSString *dataDir = self.configuration.torTempDirPath;
+    NSString *dataDir = self.configuration.torDataDirectoryPath;
     NSString *torrcPath = self.configuration.torrcPath;
     NSString *geoipPath = self.configuration.geoipPath;
     NSString *controlPort = [NSString stringWithFormat:@"%lu", (unsigned long)self.configuration.controlPort];

--- a/CPAProxyTests/CPAProxyManagerTests.m
+++ b/CPAProxyTests/CPAProxyManagerTests.m
@@ -26,7 +26,7 @@
     
     [Expecta setAsynchronousTestTimeout:60 * 5]; // 5 minutes. Sometimes Tor takes a long time to bootstrap
     
-    self.configuration = [CPAConfiguration configurationWithTorrcPath:self.torrcPath geoipPath:self.geoipPath];
+    self.configuration = [CPAConfiguration configurationWithTorrcPath:self.torrcPath geoipPath:self.geoipPath torDataDirectoryPath:nil];
     self.proxyManager = [CPAProxyManager proxyWithConfiguration:self.configuration];
 }
 
@@ -54,6 +54,25 @@
     expect(blockError).will.beNil();
     expect(blockSocksHost).willNot.beNil();
     expect(blockSocksPort).willNot.equal(0);
+}
+
+- (void)testTorDataDirectory
+{
+    NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
+    
+    CPAConfiguration *config = [CPAConfiguration configurationWithTorrcPath:self.torrcPath geoipPath:self.geoipPath torDataDirectoryPath:documentsDirectory];
+    
+    expect(config.torDataDirectoryPath).willNot.beNil();
+    expect(config.torDataDirectoryPath).willNot.equal(documentsDirectory);
+    
+    NSString *directory = [[NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) firstObject] stringByAppendingPathComponent:@"com.cpaproxy"];
+    
+    config = [CPAConfiguration configurationWithTorrcPath:self.torrcPath geoipPath:self.geoipPath torDataDirectoryPath:directory];
+    expect(config.torDataDirectoryPath).willNot.beNil();
+    expect(config.torDataDirectoryPath).will.equal(directory);
+    
+    config = [CPAConfiguration configurationWithTorrcPath:self.torrcPath geoipPath:self.geoipPath torDataDirectoryPath:nil];
+    expect(config.torDataDirectoryPath).willNot.beNil();
 }
 
 @end


### PR DESCRIPTION
By making it configurable instead of a random tmp directory the data can persist between launches.
