### PR TITLE
Verify GPG signatures for OpenSSL / libevent / tor

### DIFF
--- a/scripts/build-libevent.sh
+++ b/scripts/build-libevent.sh
@@ -1,8 +1,33 @@
 #!/bin/bash
 set -e
 
+VERIFYGPG=true
+
 if [ ! -e "libevent-${LIBEVENT_VERSION}.tar.gz" ]; then
 	curl -LO "https://github.com/downloads/libevent/libevent/libevent-${LIBEVENT_VERSION}.tar.gz"  --retry 5
+fi
+
+# Download GPG signature
+if [ ! -e "libevent-${OPENSSL_VERSION}.tar.gz.asc" ]; then
+  curl -LO "https://github.com/downloads/libevent/libevent/libevent-${LIBEVENT_VERSION}.tar.gz.asc" --retry 5
+fi
+
+# Verify signature
+if $VERIFYGPG; then
+  if out=$(gpg --status-fd 1 --verify "libevent-${LIBEVENT_VERSION}.tar.gz.asc" "libevent-${LIBEVENT_VERSION}.tar.gz" 2>/dev/null)
+    echo "$out" | grep -qs "^\[GNUPG:\] VALIDSIG"; then
+      echo "$out" | egrep "GOODSIG|VALIDSIG"
+      echo "Verified libevent GPG signature..."
+    elif echo "$out" | grep -qs "^\[GNUPG:\] BADSIG"; then
+      echo "$out" >&2
+      echo "Invalid signature for libevent!"
+      echo "It might be time to freak out!"
+      exit 1
+    else
+      echo "Couldn't verify libevent signature."
+      echo "Have you imported a libevent public key?"
+      exit 1
+  fi
 fi
 
 # Extract source


### PR DESCRIPTION
Seems like a good idea, as in issue #8. Lifted from iOS-OnionBrowser. Seems to work after pulling in the required keys.

```
gpg --search-keys --keyserver hkp://pool.sks-keyservers.net "matt@openssl.org"
gpg --search-keys --keyserver hkp://pgp.mit.edu "nickm@wangafu.net"
gpg --search-keys --keyserver hkp://pgp.mit.edu "arma@torproject.org"
```