### PR TITLE
Runloop fix

### DIFF
--- a/CPAProxy/CPAProxyManager.m
+++ b/CPAProxy/CPAProxyManager.m
@@ -148,7 +148,9 @@ typedef NS_ENUM(NSUInteger, CPAControlPortStatus) {
     // This is a pretty ungly hack but it will have to do for the moment.
     // Wait for a constant amount of time after starting the main Tor client before opening a socket
     // and send an authentication message.
-    [self performSelector:@selector(connectSocket) withObject:nil afterDelay:CPAConnectToTorSocketDelay];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(CPAConnectToTorSocketDelay * NSEC_PER_SEC)), self.workQueue, ^{
+        [self connectSocket];
+    });
 }
 
 - (void)connectSocket

--- a/CPAProxyTests/CPAProxyTestCase.h
+++ b/CPAProxyTests/CPAProxyTestCase.h
@@ -8,9 +8,6 @@
 
 #import <XCTest/XCTest.h>
 
-#define EXP_SHORTHAND YES
-#import "Expecta.h"
-
 @interface CPAProxyTestCase : XCTestCase
 @property(nonatomic, copy, readonly) NSString *torrcPath;
 @property(nonatomic, copy, readonly) NSString *geoipPath;

--- a/Podfile
+++ b/Podfile
@@ -3,5 +3,4 @@ source 'https://github.com/CocoaPods/Specs.git'
 target :CPAProxyTests do
     platform :ios, '7.0'
     pod 'CPAProxy', :path => './CPAProxy.podspec'
-    pod 'Expecta', '~> 0.3'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,19 +2,16 @@ PODS:
   - CocoaAsyncSocket (7.3.5)
   - CPAProxy (1.0.0):
     - CocoaAsyncSocket
-  - Expecta (0.3.1)
 
 DEPENDENCIES:
   - CPAProxy (from `./CPAProxy.podspec`)
-  - Expecta (~> 0.3)
 
 EXTERNAL SOURCES:
   CPAProxy:
     :path: ./CPAProxy.podspec
 
 SPEC CHECKSUMS:
-  CocoaAsyncSocket: 45bdbbc1c0a5ed0640ff4c42af325ba43a2f099a
-  CPAProxy: c3df549999514de2c04633d20a79b00daf627ddb
-  Expecta: 03aabd0a89d8dea843baecb19a7fd7466a69a31d
+  CocoaAsyncSocket: 94c582a5bef4bb0f51b6ebf3e1b561d9091a68ba
+  CPAProxy: 2f0d2ef592b28e0686b5a100ad663bdd3e51900b
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.36.0


### PR DESCRIPTION
I was having issues with Expecta so I switched to the built in async testing provided by Xcode.

Also was having issue starting Tor from a background NSOperationQueue and found that using `dispatch_after` instead of `performSelector:withObject:afterDelay:` worked. This should have the same effect.

I wonder in the future if it would be better to just try and established a connection to the control port immediately and then retry every 0.5 seconds (or other duration) until the connection is successful instead of trying only once after 0.5 seconds.