### PR TITLE
Fix for the SOCKS isolation test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode7.3
 
 install:
   - export ARCHS="i386"   # Only build dependencies for i386 to speed things up

--- a/CPAProxy/CPAProxyResponseParser.m
+++ b/CPAProxy/CPAProxyResponseParser.m
@@ -22,7 +22,7 @@
 + (CPAResponseType)responseTypeForResponse:(NSString *)response
 {
     NSInteger statusCode = [self statusCodeForResponse:response];
-    if (!statusCode == 0) {
+    if (!(statusCode == 0)) {
         int digits =  (int) log10(statusCode);
         NSInteger signifcantDigit = statusCode / pow(10, digits);
         

--- a/CPAProxyTests/CPAProxyTestCase.m
+++ b/CPAProxyTests/CPAProxyTestCase.m
@@ -7,7 +7,6 @@
 //
 
 #import "CPAProxyTestCase.h"
-@import CPAProxy;
 
 @interface CPAProxyTestCase ()
 @property(nonatomic, copy, readwrite) NSString *torrcPath;
@@ -19,7 +18,7 @@
 - (void)setUp
 {
     [super setUp];
-    NSURL *cpaProxyBundleURL = [[NSBundle bundleForClass:[CPAProxyManager class]] URLForResource:@"CPAProxy" withExtension:@"bundle"];
+    NSURL *cpaProxyBundleURL = [[NSBundle bundleForClass:NSClassFromString(@"CPAProxyManager")] URLForResource:@"CPAProxy" withExtension:@"bundle"];
     XCTAssertNotNil(cpaProxyBundleURL, @"cpaProxyBundleURL should not be nil!");
     NSBundle *cpaProxyBundle = [NSBundle bundleWithURL:cpaProxyBundleURL];
     self.torrcPath = [cpaProxyBundle pathForResource:@"torrc" ofType:nil];

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -40,7 +40,7 @@ fi
 
 # Versions
 export MIN_IOS_VERSION="8.0"
-export OPENSSL_VERSION="1.0.2h"
+export OPENSSL_VERSION="1.0.2i"
 export LIBEVENT_VERSION="2.0.22-stable"
 export TOR_VERSION="0.2.8.7"
 

--- a/scripts/build-libevent.sh
+++ b/scripts/build-libevent.sh
@@ -13,6 +13,8 @@ tar zxf "${ARCHIVE_NAME}.tar.gz"
 
 pushd "${ARCHIVE_NAME}"
 
+   patch -p3 < "${TOPDIR}/patches/libevent-configure.diff" configure
+
    CC="${CLANG}"
    LDFLAGS="-L${ARCH_BUILT_DIR} -fPIE -miphoneos-version-min=${MIN_IOS_VERSION}"
    CFLAGS=" -arch ${ARCH} -fPIE -isysroot ${SDK_PATH} -I${ARCH_BUILT_HEADERS_DIR} -miphoneos-version-min=${MIN_IOS_VERSION}"
@@ -20,7 +22,7 @@ pushd "${ARCHIVE_NAME}"
 
    if [ "${ARCH}" == "i386" ] || [ "${ARCH}" == "x86_64" ];
    	then
-		EXTRA_CONFIG=""
+      EXTRA_CONFIG="--host=${ARCH}-apple-darwin"
 	else
 		EXTRA_CONFIG="--host=arm-apple-darwin"
 	fi

--- a/scripts/build-tor.sh
+++ b/scripts/build-tor.sh
@@ -15,13 +15,14 @@ pushd "tor-${TOR_VERSION}"
 	# Apply patches
 	patch -p3 < "${TOPDIR}/patches/tor-nsenviron.diff"
 	patch -p3 < "${TOPDIR}/patches/tor-ptrace.diff"
+	patch -p3 < "${TOPDIR}/patches/tor-configure.diff" configure
 
 	LDFLAGS="-L${ARCH_BUILT_DIR} -fPIE -miphoneos-version-min=${MIN_IOS_VERSION}"
 	CFLAGS="-arch ${ARCH} -fPIE -isysroot ${SDK_PATH} -I${ARCH_BUILT_HEADERS_DIR} -miphoneos-version-min=${MIN_IOS_VERSION}"
 	CPPFLAGS="-arch ${ARCH} -fPIE -isysroot ${SDK_PATH} -I${ARCH_BUILT_HEADERS_DIR} -miphoneos-version-min=${MIN_IOS_VERSION}"
 
 	if [ "${ARCH}" == "i386" ] || [ "${ARCH}" == "x86_64" ]; then
-        EXTRA_CONFIG=""
+		EXTRA_CONFIG="--host=${ARCH}-apple-darwin"
     else
         EXTRA_CONFIG="--host=arm-apple-darwin"
     fi

--- a/scripts/patches/libevent-configure.diff
+++ b/scripts/patches/libevent-configure.diff
@@ -1,0 +1,11 @@
+--- configure.orig	2016-09-21 13:24:02.000000000 +0200
++++ configure	2016-09-21 13:24:22.000000000 +0200
+@@ -13164,7 +13164,7 @@
+ fi
+ 
+ 
+-for ac_func in gettimeofday vasprintf fcntl clock_gettime strtok_r strsep
++for ac_func in gettimeofday vasprintf fcntl strtok_r strsep
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/scripts/patches/tor-configure.diff
+++ b/scripts/patches/tor-configure.diff
@@ -1,0 +1,17 @@
+--- configure.orig	2016-08-24 17:02:51.000000000 +0200
++++ configure	2016-09-22 21:38:46.000000000 +0200
+@@ -7050,14 +7050,12 @@
+         accept4 \
+         backtrace \
+         backtrace_symbols_fd \
+-        clock_gettime \
+ 	eventfd \
+ 	explicit_bzero \
+ 	timingsafe_memcmp \
+         flock \
+         ftime \
+         getaddrinfo \
+-        getentropy \
+         getifaddrs \
+         getpass \
+         getrlimit \


### PR DESCRIPTION
The SOCKS isolation test kept producing SSL errors, both locally and on Travis, my workaround is to do a manual "verification". 
In addition, it sometimes failed to read data, and retrying didn't help. I suspect the server rejected the IP-address, a workaround there is to reinitialize the socket with the same parameters, that seems to eventually enable the socket to connect and read data.

testSendingHUP keeps failing still, the callback never seems to get called, but the test does pass locally, both in XCode and with XCTool.