### PR TITLE
Null checking completion blocks

### DIFF
--- a/CPAProxy/CPAProxyManager.m
+++ b/CPAProxy/CPAProxyManager.m
@@ -279,7 +279,9 @@ typedef NS_ENUM(NSUInteger, CPAControlPortStatus) {
         __weak typeof(self)weakSelf = self;
         dispatch_async(self.callbackQueue, ^{
             __strong typeof(weakSelf)strongSelf = weakSelf;
-            strongSelf.progressBlock(progress,summaryString);
+            if (strongSelf.progressBlock) {
+                strongSelf.progressBlock(progress, summaryString);
+            }
         });
     }
 
@@ -294,10 +296,9 @@ typedef NS_ENUM(NSUInteger, CPAControlPortStatus) {
             __weak typeof(self)weakSelf = self;
             dispatch_async(self.callbackQueue, ^{
                 __strong typeof(weakSelf)strongSelf = weakSelf;
-                if (!strongSelf) {
-                    return;
+                if (strongSelf.completionBlock) {
+                    strongSelf.completionBlock(socksHost, socksPort, nil);
                 }
-                strongSelf.completionBlock(socksHost, socksPort, nil);
                 strongSelf.completionBlock = nil;
                 strongSelf.progressBlock = nil;
             });
@@ -338,7 +339,9 @@ typedef NS_ENUM(NSUInteger, CPAControlPortStatus) {
         __weak typeof(self)weakSelf = self;
         dispatch_async(self.callbackQueue, ^{
             __strong typeof(weakSelf)strongSelf = weakSelf;
-            strongSelf.completionBlock(nil,0,error);
+            if (strongSelf.completionBlock) {
+                strongSelf.completionBlock(nil, 0, error);
+            }
             strongSelf.completionBlock = nil;
             strongSelf.progressBlock = nil;
         });


### PR DESCRIPTION
There need to be a null checking before block is executed. It need to be done before execution - checking its value before dispatch_async is not enough.