### PR TITLE
Add patch for TROVE-2018-004 since 0.3.0.x branch is deprecated

### DIFF
--- a/scripts/build-tor.sh
+++ b/scripts/build-tor.sh
@@ -15,6 +15,7 @@ pushd "tor-${TOR_VERSION}"
 	# Apply patches
 	patch -p3 < "${TOPDIR}/patches/tor-nsenviron.diff"
 	patch -p3 < "${TOPDIR}/patches/tor-ptrace.diff"
+	patch -p1 < "${TOPDIR}/patches/tor-trove-2018-004.patch"
 
 	LDFLAGS="-L${ARCH_BUILT_DIR} -fPIE ${PLATFORM_VERSION_MIN}"
 	CFLAGS="-arch ${ARCH} -fPIE -isysroot ${SDK_PATH} -I${ARCH_BUILT_HEADERS_DIR} ${PLATFORM_VERSION_MIN}"

--- a/scripts/build-tor.sh
+++ b/scripts/build-tor.sh
@@ -3,7 +3,8 @@ set -e
 
 # Download source
 if [ ! -e "tor-${TOR_VERSION}.tar.gz" ]; then
-  curl -O "https://dist.torproject.org/tor-${TOR_VERSION}.tar.gz" --retry 5
+  #curl -O "https://dist.torproject.org/tor-${TOR_VERSION}.tar.gz" --retry 5
+  curl -O "https://archive.torproject.org/tor-package-archive/tor-${TOR_VERSION}.tar.gz" --retry 5
 fi
 
 # Extract source

--- a/scripts/patches/tor-trove-2018-004.patch
+++ b/scripts/patches/tor-trove-2018-004.patch
@@ -1,0 +1,48 @@
+From a83650852d3cd00c9916cae74d755ae55a6b506d Mon Sep 17 00:00:00 2001
+From: Nick Mathewson <nickm@torproject.org>
+Date: Wed, 14 Feb 2018 10:45:57 -0500
+Subject: Add another NULL-pointer fix for protover.c.
+
+This one can only be exploited if you can generate a correctly
+signed consensus, so it's not as bad as 25074.
+
+Fixes bug 25251; also tracked as TROVE-2018-004.
+---
+ changes/trove-2018-004 | 8 ++++++++
+ src/or/protover.c      | 5 +++++
+ 2 files changed, 13 insertions(+)
+ create mode 100644 changes/trove-2018-004
+
+diff --git a/changes/trove-2018-004 b/changes/trove-2018-004
+new file mode 100644
+index 0000000..37e0a89
+--- /dev/null
++++ b/changes/trove-2018-004
+@@ -0,0 +1,8 @@
++  o Minor bugfixes (denial-of-service):
++    - Fix a possible crash on malformed consensus. If a consensus had
++      contained an unparseable protocol line, it could have made clients
++      and relays crash with a null-pointer exception. To exploit this
++      issue, however, an attacker would need to be able to subvert the
++      directory-authority system. Fixes bug 25251; bugfix on
++      0.2.9.4-alpha. Also tracked as TROVE-2018-004.
++
+diff --git a/src/or/protover.c b/src/or/protover.c
+index a750774..e63036f 100644
+--- a/src/or/protover.c
++++ b/src/or/protover.c
+@@ -624,6 +624,11 @@ protover_all_supported(const char *s, char **missing_out)
+   }
+ 
+   smartlist_t *entries = parse_protocol_list(s);
++  if (BUG(entries == NULL)) {
++    log_warn(LD_NET, "Received an unparseable protocol list %s"
++             " from the consensus", escaped(s));
++    return 1;
++  }
+ 
+   missing = smartlist_new();
+ 
+-- 
+cgit v1.1
+


### PR DESCRIPTION
See: https://trac.torproject.org/projects/tor/ticket/25251
From: https://gitweb.torproject.org/tor.git/commit/?h=maint-0.3.1&id=a83650852d3cd00c9916cae74d755ae55a6b506d

More for the sake of it.

> It may be worth deprecating CPAProxy in favor of Tor.framework sooner rather than later.

I concur.